### PR TITLE
feat: playwright in a container for service-monitor to access

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,9 +57,22 @@ services:
     volumes:
       - service-monitor-data:/datastore
       - /dev/shm:/dev/shm
+    environment:
+      - PLAYWRIGHT_DRIVER_URL=ws://service-playwright:3000
     restart: unless-stopped
     networks:
       - bandwidth
+    depends_on:
+      - playwright
+
+  service-playwright:
+    image: ghcr.io/dgtlmoon/changedetection-playwright:latest
+    container_name: service-playwright
+    restart: unless-stopped
+    networks:
+      - bandwidth
+    expose:
+      - "3000"
 
   website-main:
     image: ghcr.io/bandwidth-gig-guide/website-main:latest


### PR DESCRIPTION
allows for changedetection.io to to create image-based diffs instead of just text.