### PR TITLE
feat: add workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,30 @@
+name: Update Production Deployment
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PATH_IN_VM: deployment/
+
+jobs:
+  deploy:
+    name: Update Production Deployment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git & Docker Pull
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DO_HOST }}
+          username: ${{ secrets.DO_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          script: |
+            cd ${{ env.PATH_IN_VM }}
+            git pull
+            docker compose pull
+            docker compose up -d --remove-orphans
+            docker image prune -af || true

--- a/.github/workflows/weekly-image-updates.yaml
+++ b/.github/workflows/weekly-image-updates.yaml
@@ -1,0 +1,28 @@
+name: Weekly Image Updates
+
+on:
+  schedule:
+    - cron: "0 20 * * 0"  # Runs every Monday at 6am Melbourne time (AEST/AEDT)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  PATH_IN_VM: deployment/
+
+jobs:
+  update-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Docker images on server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DO_HOST }}
+          username: ${{ secrets.DO_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          script: |
+            cd ${{ env.PATH_IN_VM }}
+            docker compose pull
+            docker compose up -d --remove-orphans
+            docker image prune -af || true


### PR DESCRIPTION
Add workflow to sync the production env with changes to the main branch.

Add workflow to update all images weekly on Monday at 6am. Useful for keeping third-party images such as keycloak and changedetection.io up-to-date.
